### PR TITLE
changed unshutdown to wakeup

### DIFF
--- a/dorfctl.py
+++ b/dorfctl.py
@@ -18,7 +18,7 @@ status_dict = {
 
 trans_dict = {
     "shutdown": "shortcut:shutdown"
-    "unshutdown": "shortcut:unshutdown"
+    "wakeup": "shortcut:unshutdown"
     "amps": "shortcut:amps",
     "hackcenter": "hackcenter_w",
     "rotlicht": "lounge_t2a",


### PR DESCRIPTION
There is no word named "unshutdown" -> "wakeup" is more user-friendly.